### PR TITLE
Batch `where ... in (...)` queries

### DIFF
--- a/src/main/java/link/klauser/flatfetcher/Accessor.java
+++ b/src/main/java/link/klauser/flatfetcher/Accessor.java
@@ -27,34 +27,71 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.internal.SessionImpl;
 import org.hibernate.persister.entity.UniqueKeyLoadable;
 
+/**
+ * <p>
+ * Cached implementation of a getter ({@link #get(Object)}) and setter ({@link #set(EntityManager, Object, Object)}) on an
+ * attribute ({@link #attr()}).
+ * </p>
+ * <p>
+ *     The setter is aware of the persistence context and will set values in such a way that the persistence provider does not
+ *     provide the assignment as a change to the entity.
+ * </p>
+ * @param <X> The type of object to invoke the getter/setter on (the {@code this} pointer)
+ * @param <A> The type of value to get/set (the return type/argument type)
+ */
 @Slf4j
 abstract class Accessor<X, A> {
 
-	abstract A get(X owner);
+	public abstract A get(X owner);
 
-	void set(EntityManager entityManager, X owner, A value) {
+	public void set(EntityManager entityManager, X owner, A value) {
 		set(owner, value);
 		setLoadedStatus(entityManager, owner, value);
 	}
 
 	protected abstract void set(X owner, A value);
 
-	abstract Attribute<X, A> attr();
+	/**
+	 * The underlying attribute. This value is immutable. Never {@code null}.
+	 */
+	public abstract Attribute<X, A> attr();
 
+	/**
+	 * The {@link #attr()} as a {@link SingularAttribute}.
+	 * @throws ClassCastException if the {@link #attr()} is not a {@link SingularAttribute}.
+	 */
 	public SingularAttribute<X, A> singularAttr() {
 		// This is type-safe because IF `attr` is a `SingularAttribute`, then the only `SingularAttribute` it can be, is a
 		// `SingularAttribute<X, A>`.
 		return (SingularAttribute<X, A>) attr();
 	}
 
+	/**
+	 * The {@link #attr()} as a {@link PluralAttribute}.
+	 * @throws ClassCastException if the {@link #attr()} is not a {@link PluralAttribute}.
+	 */
 	public PluralAttribute<X, A, ?> pluralAttr() {
 		// This is type-safe because IF `attr` is a `PluralAttribute`, then the only `PluralAttribute` it can be, is a
 		// `PluralAttribute<X, A, ?>`.
 		return (PluralAttribute<X, A, ?>) attr();
 	}
 
+	/**
+	 * <p>
+	 * Constructs a fresh accessor for the id "companion" attribute of the supplied association attribute.
+	 * </p>
+	 * <p>
+	 *  Searches for an attribute with the suffix `{@code Id}` added to the end. For example, if the attribute is called
+	 *  `{@code foo}`, this factory method will search for an attribute `{@code fooId}`.
+	 * </p>
+	 *
+	 * @param associationAttr The association attribute to derive the association id attribute from.
+	 * @param <C> The type of entity to search for attributes.
+	 * @param <K> The type of the id attribute (e.g., {@code long}, {@code UUID} or {@code String})
+	 * @return a fresh accessor for the id "companion" attribute of the supplied association attribute. Never {@code null}.
+	 */
 	@SuppressWarnings("unchecked")
-	static <C, K extends Serializable> Accessor<? super C, K> forIdOf(Attribute<? super C, ?> associationAttr) {
+	public static <C, K extends Serializable> Accessor<? super C, K> forIdOf(Attribute<? super C, ?> associationAttr) {
 		Attribute<? super C, ?> idAttribute;
 		var inferredAttributeName = associationAttr.getName() + "Id";
 		try {
@@ -68,81 +105,108 @@ abstract class Accessor<X, A> {
 		return of((Attribute<C, K>) idAttribute);
 	}
 
-	static <C> Accessor<? super C, ?> forPrimaryKeyOf(EntityType<? super C> entity) {
+	/**
+	 * Constructs a fresh accessor for the primary key of the supplied entity type.
+	 * @param entity The entity type to create a primary key accessor for.
+	 * @param <C> The type of entity to create a primary key accessor for.
+	 * @return a fresh accessor for the primary key of the supplied entity type.
+	 */
+	public static <C> Accessor<? super C, ?> forPrimaryKeyOf(EntityType<? super C> entity) {
 		var idAttr = entity.getId(entity.getIdType().getJavaType());
 		return of(idAttr);
 	}
 
-	@SneakyThrows
-	static <C, T> Accessor<? super C, T> of(Attribute<? super C, T> attr) {
+	/**
+	 * Constructs a fresh accessor for the supplied attribute.
+	 * @param attr The attribute to create an accessor for.
+	 * @param <C> The class to call the accessor on (the {@code this} pointer)
+	 * @param <T> The type of the value to get set (the return type/argument type)
+	 * @return a fresh accessor for the supplied attribute. Never {@code null}.
+	 */
+	public static <C, T> Accessor<? super C, T> of(Attribute<? super C, T> attr) {
 		var m = attr.getJavaMember();
 		if (m instanceof Field) {
 			var field = (Field) m;
-			field.setAccessible(true);
-			return new Accessor<>() {
-				@SuppressWarnings("unchecked")
-				@Override
-				@SneakyThrows
-				public T get(C owner) {
-					return (T) field.get(owner);
-				}
-
-				@Override
-				@SneakyThrows
-				public void set(C owner, T value) {
-					field.set(owner, value);
-				}
-
-				@Override
-				public String toString() {
-					return "accessor(" + field.getDeclaringClass().getSimpleName() + "#" + field.getName() + ")";
-				}
-
-				@SuppressWarnings({ "unchecked", "rawtypes" })
-				@Override
-				public Attribute<C, T> attr() {
-					// This is safe because we have the same bounds when we return the Accessor;
-					// We just can't _instantiate_ the the Accessor with the wildcard type. Because Java.
-					return (Attribute)attr;
-				}
-			};
+			return fieldAccessor(attr, field);
 		}
 		if (m instanceof Method) {
 			var getter = (Method) m;
-			var setterName = "s" + getter.getName().substring(1);
-			var setter = getter.getDeclaringClass().getMethod(setterName, getter.getReturnType());
-			getter.setAccessible(true);
-			setter.setAccessible(true);
-			return new Accessor<>() {
-				@SuppressWarnings("unchecked")
-				@SneakyThrows
-				@Override
-				public T get(C owner) {
-					return (T) getter.invoke(owner);
-				}
-
-				@SneakyThrows
-				@Override
-				public void set(C owner, T value) {
-					setter.invoke(owner, value);
-				}
-
-				@Override
-				public String toString() {
-					return "accessor(" + getter.getDeclaringClass().getSimpleName() + "#" + getter.getName() + ","
-							+ setter.getDeclaringClass().getSimpleName() + "#" + setter.getName() + ")";
-				}
-
-				@SuppressWarnings({ "unchecked", "rawtypes" })
-				@Override
-				public Attribute<C, T> attr() {
-					// This is safe because we have the same bounds when we return the Accessor;
-					// We just can't _instantiate_ the the Accessor with the wildcard type. Because Java.
-					return (Attribute) attr;
-				}
-			};
+			return getterSetterAccessor(attr, getter);
 		}
 		throw new FlatFetcherException("Members of type " + m.getClass().getSimpleName() + " are not supported.");
+	}
+
+	private static <C, T> Accessor<? super C, T> getterSetterAccessor(Attribute<? super C, T> attr, Method getter) {
+		var setterName = "s" + getter.getName().substring(1);
+		Method setter;
+		try {
+			setter = getter.getDeclaringClass().getMethod(setterName, getter.getReturnType());
+		}
+		catch (NoSuchMethodException e) {
+			throw FlatFetcherException.onAttr("Cannot find setter " + setterName + "(" + getter.getReturnType() +
+					") on " + getter.getDeclaringClass() + ". Needed to access attribute ", attr);
+		}
+		getter.setAccessible(true);
+		setter.setAccessible(true);
+		return new Accessor<>() {
+			@SuppressWarnings("unchecked")
+			@SneakyThrows
+			@Override
+			public T get(C owner) {
+				return (T) getter.invoke(owner);
+			}
+
+			@SneakyThrows
+			@Override
+			public void set(C owner, T value) {
+				setter.invoke(owner, value);
+			}
+
+			@Override
+			public String toString() {
+				return "accessor(" + getter.getDeclaringClass().getSimpleName() + "#" + getter.getName() + ","
+						+ setter.getDeclaringClass().getSimpleName() + "#" + setter.getName() + ")";
+			}
+
+			@SuppressWarnings({ "unchecked", "rawtypes" })
+			@Override
+			public Attribute<C, T> attr() {
+				// This is safe because we have the same bounds when we return the Accessor;
+				// We just can't _instantiate_ the the Accessor with the wildcard type. Because Java.
+				return (Attribute) attr;
+			}
+		};
+	}
+
+	private static <C, T> Accessor<? super C, T> fieldAccessor(Attribute<? super C, T> attr, Field field) {
+		field.setAccessible(true);
+		return new Accessor<>() {
+			@SuppressWarnings("unchecked")
+			@Override
+			@SneakyThrows
+			public T get(C owner) {
+				return (T) field.get(owner);
+			}
+
+			@Override
+			@SneakyThrows
+			public void set(C owner, T value) {
+				field.set(owner, value);
+			}
+
+			@Override
+			public String toString() {
+				return "accessor(" + field.getDeclaringClass().getSimpleName() + "#" + field.getName() + ")";
+			}
+
+			@SuppressWarnings({ "unchecked" })
+			@Override
+			public Attribute<C, T> attr() {
+				// This is safe because we have the same bounds when we return the Accessor;
+				// We just can't _instantiate_ the the Accessor with the wildcard type. Because Java.
+				return (Attribute<C, T>) attr;
+			}
+		};
 	}
 
 	void setLoadedStatus(EntityManager em, X owner, A value) {

--- a/src/main/java/link/klauser/flatfetcher/FetchPlan.java
+++ b/src/main/java/link/klauser/flatfetcher/FetchPlan.java
@@ -19,5 +19,5 @@ import javax.persistence.EntityManager;
 
 @FunctionalInterface
 interface FetchPlan<X, A> {
-	Collection<A> fetch(EntityManager em, Collection<? extends X> roots);
+	Collection<A> fetch(EntityManager em, Collection<? extends X> roots, int batchSize);
 }

--- a/src/main/java/link/klauser/flatfetcher/FlatFetcher.java
+++ b/src/main/java/link/klauser/flatfetcher/FlatFetcher.java
@@ -18,18 +18,72 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.persistence.Access;
+import javax.persistence.AccessType;
 import javax.persistence.AttributeNode;
 import javax.persistence.EntityManager;
+import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.metamodel.EntityType;
 import javax.persistence.metamodel.PluralAttribute;
 import javax.persistence.metamodel.SingularAttribute;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
 
+/**
+ * <p>
+ * Efficiently fetches named entity graphs in bulk. Avoids both N+1 and accidental cartesian products.
+ * </p>
+ * <p>
+ *     There are a number of pre-requisites for flat fetcher to work as expected:
+ * </p>
+ * <ol>
+ *     <li>The persistence provider has to be Hibernate. Other JPA implementations are not supported.</li>
+ *     <li>For {@code @XxxToOne} mappings, lazy initialization byte code enhancement needs to be applied to your entity classes.
+ *     See <a href="https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#BytecodeEnhancement">
+ *         Section 5.2 Bytecode Enhancement in the Hibernate documentation</a>.</li>
+ *     <li>Your associations need to be marked as {@link FetchType#LAZY}.</li>
+ *     <li>Each {@code XxxToOne} association needs to be marked with {@code @}{@link LazyToOne}{@code (}{@link LazyToOneOption#NO_PROXY}{@code )}.</li>
+ *     <li>Access to associations needs to happen through properties:
+ *     {@code @}{@link Access}{@code (}{@link AccessType#PROPERTY}{@code )}. This restriction only applies to associations.
+ *     Ordinary columns can use {@link AccessType#FIELD}.</li>
+ *     <li>Each {@code XxxToOne} association with a {@code @}{@link javax.persistence.JoinColumn} needs to be accompanied by a
+ *     second mapping of the same underlying DB column to access the join column value (the FK ID) directly. The ID-attribute has
+ *     to have the same name as the association but with the suffix {@code "Id"}. Depending on the configured naming strategy, you
+ *     might have to explicitly specify the name of the join column.
+ *     </li>
+ *     <li>You need to have a {@code @}{@link javax.persistence.NamedEntityGraph} on your entity that includes all of the
+ *     attributes that you want to fetch. {@link FetchType#EAGER} attributes will not be fetched unless they are explicitly
+ *     included in the entity graph.</li>
+ * </ol>
+ * <p>Example:</p>
+ * <pre>{@code
+ *   @JoinColumn(name = "fooId")
+ *   @ManyToOne(fetch = FetchType.LAZY, optional = false)
+ *   @LazyToOne(LazyToOneOption.NO_PROXY)
+ *   @Access(AccessType.PROPERTY)
+ *   Foo foo;
+ *
+ *   @Column(name = "fooId", insertable = false, updatable = false)
+ *   UUID fooId;
+ * }</pre>
+ * <p>
+ *     {@link FlatFetcher} needs to perform some reflection to figure out, how to perform the desired queries. These "query plans"
+ *     are cached in a {@link FlatFetcher} instance, but not shared between flat fetcher instances. It is intended to be used
+ *     with a proxied {@link EntityManager} and shared between threads.
+ * </p>
+ * <p>
+ *     While concurrent use of {@link FlatFetcher} may result in some duplicate work when determining query plans,
+ *     {@link FlatFetcher} is thread-safe.
+ * </p>
+ */
 @RequiredArgsConstructor
 @Slf4j
 public class FlatFetcher {
@@ -37,15 +91,21 @@ public class FlatFetcher {
 	@lombok.NonNull
 	final EntityManager em;
 
-	@Value
-	static class PlanKey {
-		@lombok.NonNull
+	/**
+	 * <p>Upper limit on how many rows to request in a single query.</p>
+	 * <p>The {@link FlatFetcher} mostly produces
+	 * {@code where ... in (...)} queries, which Hibernate translates as {@code where ... in (?, ?, ..., ?)}. Some RDBMSs,
+	 * such as Oracle DB, have limits on how long an SQL query can be and how long the {@code in} list can be.</p>
+	 */
+	@Getter
+	@Setter
+	volatile int batchSize = 500;
 
-		EntityType<?> entityType;
-		@lombok.NonNull
-		String attributeName;
-	}
-
+	/**
+	 * A tuple of a collection of {@link #roots()} and the union of a {@link javax.persistence.EntityGraph}
+	 * and {@link javax.persistence.Subgraph}.
+	 * @param <X> The type of entity that the graph object describes fetching for.
+	 */
 	interface FetchNode<X> {
 
 		String name();
@@ -57,9 +117,32 @@ public class FlatFetcher {
 		Collection<X> roots();
 	}
 
+	@Value
+	static class PlanKey {
+		@lombok.NonNull
+
+		EntityType<?> entityType;
+		@lombok.NonNull
+		String attributeName;
+	}
+
 	@SuppressWarnings("rawtypes")
 	final ConcurrentHashMap<PlanKey, FetchPlan> attributePlanCache = new ConcurrentHashMap<>();
 
+	/**
+	 * <p>
+	 * Fetches associated entities for the associations included in the {@code @}{@link javax.persistence.NamedEntityGraph} with
+	 * the supplied {@code entityGraphName} for all of the {@code roots}.
+	 * </p>
+	 * <p>
+	 *     Fills forward and, where possible, backwards (mappedBy) relations.
+	 * </p>
+	 * @param tag Entity type on which entity graph attributes are looked up.
+	 * @param roots The entities for which to fetch the associations listed in the entity graph
+	 * @param entityGraphName The name of the entity graph that indicates <em>which</em> associations to fetch for {@code roots}.
+	 * @param <X> The type of entities to fetch associations for.
+	 * @see #setBatchSize(int)
+	 */
 	public <X> void fetch(Class<X> tag, Collection<X> roots, String entityGraphName) {
 		if (roots.isEmpty()) {
 			return;
@@ -118,7 +201,7 @@ public class FlatFetcher {
 	private <X, A> void fetchAttribute(List<FetchNode<?>> fetchQueue, FetchNode<X> fetchNode,
 			EntityType<X> currentRootType, AttributeNode<A> attributeNode) {
 		FetchPlan<X, A> planForNode = fetchPlanFor(currentRootType, attributeNode);
-		var subRoots = planForNode.fetch(em, fetchNode.roots());
+		var subRoots = planForNode.fetch(em, fetchNode.roots(), getBatchSize());
 		if(!subRoots.isEmpty()) {
 			for (var subgraphEntry : attributeNode.getSubgraphs().entrySet()) {
 				var subgraphName = fetchNode.name() + "." + attributeNode.getAttributeName()

--- a/src/main/java/link/klauser/flatfetcher/FlatFetcherException.java
+++ b/src/main/java/link/klauser/flatfetcher/FlatFetcherException.java
@@ -17,26 +17,28 @@ package link.klauser.flatfetcher;
 import java.io.Serializable;
 import javax.persistence.metamodel.Attribute;
 
-
+/**
+ * Usually indicates an error during the introspection/reflection phase of the {@link FlatFetcher}.
+ */
 public class FlatFetcherException extends RuntimeException implements Serializable {
 
-	FlatFetcherException(String message) {
+	public FlatFetcherException(String message) {
 		super(message);
 	}
 
-	FlatFetcherException(String message, Throwable cause) {
+	public FlatFetcherException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
-	FlatFetcherException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+	protected FlatFetcherException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
 		super(message, cause, enableSuppression, writableStackTrace);
 	}
 
-	static FlatFetcherException onAttr(String msg, Attribute<?, ?> metaAttr) {
+	public static FlatFetcherException onAttr(String msg, Attribute<?, ?> metaAttr) {
 		return onAttr(msg, metaAttr, null);
 	}
 
-	static FlatFetcherException onAttr(String msg, Attribute<?, ?> metaAttr, Throwable cause) {
+	public static FlatFetcherException onAttr(String msg, Attribute<?, ?> metaAttr, Throwable cause) {
 		return new FlatFetcherException(msg +
 				PlanUtils.shortAttrDescription(metaAttr), cause);
 	}


### PR DESCRIPTION
Avoid constructing queries with obscene numbers of parameters (>1000).

Fixes #1 